### PR TITLE
feat(asn1): support non-universal tags

### DIFF
--- a/assets/rocket_mod.asn
+++ b/assets/rocket_mod.asn
@@ -5,11 +5,11 @@ BEGIN
   {
      range     INTEGER,
      name      OCTET STRING,
-     ident     OBJECT IDENTIFIER, 
+     ident     OBJECT IDENTIFIER,
      payload   CHOICE
      { 
         one    INTEGER,  
         many   SEQUENCE OF INTEGER  
      }
-  }                                                     
+  }
 END

--- a/assets/tagged.asn
+++ b/assets/tagged.asn
@@ -1,0 +1,17 @@
+Tagged-Test DEFINITIONS ::= BEGIN
+  Tagged ::= SEQUENCE {
+     name      OCTET STRING,
+     app       CHOICE { 
+        imp    [APPLICATION 0] IMPLICIT INTEGER,
+        imc    [APPLICATION 1] IMPLICIT SEQUENCE OF INTEGER,
+        exp    [APPLICATION 2] INTEGER,
+        exc    [APPLICATION 3] SEQUENCE OF INTEGER
+     },
+     ctx       CHOICE {
+        imp    [4] IMPLICIT INTEGER,
+        imc    [5] IMPLICIT SEQUENCE OF INTEGER,
+        exp    [6] INTEGER,
+        exc    [7] SEQUENCE OF INTEGER
+     }
+  }
+END

--- a/assets/tagged.asn
+++ b/assets/tagged.asn
@@ -1,17 +1,16 @@
 Tagged-Test DEFINITIONS ::= BEGIN
   Tagged ::= SEQUENCE {
      name      OCTET STRING,
-     app       CHOICE { 
-        imp    [APPLICATION 0] IMPLICIT INTEGER,
-        imc    [APPLICATION 1] IMPLICIT SEQUENCE OF INTEGER,
-        exp    [APPLICATION 2] INTEGER,
-        exc    [APPLICATION 3] SEQUENCE OF INTEGER
-     },
-     ctx       CHOICE {
-        imp    [4] IMPLICIT INTEGER,
-        imc    [5] IMPLICIT SEQUENCE OF INTEGER,
-        exp    [6] INTEGER,
-        exc    [7] SEQUENCE OF INTEGER
+     payload       CHOICE {
+        -- a=Appl, c=Ctxt, i=implicit, e=explicit, p=primitive, c=constructed
+        aip    [APPLICATION 0] IMPLICIT INTEGER,
+        aic    [APPLICATION 1] IMPLICIT SEQUENCE OF INTEGER,
+        aep    [APPLICATION 2] INTEGER,
+        aec    [APPLICATION 3] SEQUENCE OF INTEGER,
+        cip    [4] IMPLICIT INTEGER,
+        cic    [5] IMPLICIT SEQUENCE OF INTEGER,
+        cep    [6] INTEGER,
+        cec    [7] SEQUENCE OF INTEGER
      }
   }
 END

--- a/pdm.lock
+++ b/pdm.lock
@@ -126,7 +126,7 @@ summary = "More routines for operating on iterables, beyond itertools"
 
 [[package]]
 name = "mypy"
-version = "0.960"
+version = "0.961"
 requires_python = ">=3.6"
 summary = "Optional static typing for Python"
 dependencies = [
@@ -285,7 +285,7 @@ name = "recordflux"
 version = "0.6.0rc0"
 requires_python = ">=3.7"
 git = "https://github.com/Componolit/RecordFlux"
-revision = "2b088f969f948f4a8d7d677da2dd161ddf4d577e"
+revision = "debf11c41d5d57972adeac1cd7c9a52ade4e9f9a"
 summary = "A toolset for the formal specification of messages and the generation of verifiable binary parsers and message generators."
 dependencies = [
     "RecordFlux-parser==0.10.0",
@@ -457,30 +457,30 @@ content_hash = "sha256:538cff764f48185f366cb3eaf0e1364373777c65b39401db43961b102
     {file = "more_itertools-8.13.0-py3-none-any.whl", hash = "sha256:c5122bffc5f104d37c1626b8615b511f3427aa5389b94d61e5ef8236bfbc3ddb"},
     {file = "more-itertools-8.13.0.tar.gz", hash = "sha256:a42901a0a5b169d925f6f217cd5a190e32ef54360905b9c39ee7db5313bfec0f"},
 ]
-"mypy 0.960" = [
-    {file = "mypy-0.960-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3a3e525cd76c2c4f90f1449fd034ba21fcca68050ff7c8397bb7dd25dd8b8248"},
-    {file = "mypy-0.960-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7a76dc4f91e92db119b1be293892df8379b08fd31795bb44e0ff84256d34c251"},
-    {file = "mypy-0.960-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ffdad80a92c100d1b0fe3d3cf1a4724136029a29afe8566404c0146747114382"},
-    {file = "mypy-0.960-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7d390248ec07fa344b9f365e6ed9d205bd0205e485c555bed37c4235c868e9d5"},
-    {file = "mypy-0.960-cp310-cp310-win_amd64.whl", hash = "sha256:925aa84369a07846b7f3b8556ccade1f371aa554f2bd4fb31cb97a24b73b036e"},
-    {file = "mypy-0.960-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:239d6b2242d6c7f5822163ee082ef7a28ee02e7ac86c35593ef923796826a385"},
-    {file = "mypy-0.960-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f1ba54d440d4feee49d8768ea952137316d454b15301c44403db3f2cb51af024"},
-    {file = "mypy-0.960-cp36-cp36m-win_amd64.whl", hash = "sha256:cb7752b24528c118a7403ee955b6a578bfcf5879d5ee91790667c8ea511d2085"},
-    {file = "mypy-0.960-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:826a2917c275e2ee05b7c7b736c1e6549a35b7ea5a198ca457f8c2ebea2cbecf"},
-    {file = "mypy-0.960-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3eabcbd2525f295da322dff8175258f3fc4c3eb53f6d1929644ef4d99b92e72d"},
-    {file = "mypy-0.960-cp37-cp37m-win_amd64.whl", hash = "sha256:f47322796c412271f5aea48381a528a613f33e0a115452d03ae35d673e6064f8"},
-    {file = "mypy-0.960-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2c7f8bb9619290836a4e167e2ef1f2cf14d70e0bc36c04441e41487456561409"},
-    {file = "mypy-0.960-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fbfb873cf2b8d8c3c513367febde932e061a5f73f762896826ba06391d932b2a"},
-    {file = "mypy-0.960-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cc537885891382e08129d9862553b3d00d4be3eb15b8cae9e2466452f52b0117"},
-    {file = "mypy-0.960-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:481f98c6b24383188c928f33dd2f0776690807e12e9989dd0419edd5c74aa53b"},
-    {file = "mypy-0.960-cp38-cp38-win_amd64.whl", hash = "sha256:29dc94d9215c3eb80ac3c2ad29d0c22628accfb060348fd23d73abe3ace6c10d"},
-    {file = "mypy-0.960-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:33d53a232bb79057f33332dbbb6393e68acbcb776d2f571ba4b1d50a2c8ba873"},
-    {file = "mypy-0.960-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8d645e9e7f7a5da3ec3bbcc314ebb9bb22c7ce39e70367830eb3c08d0140b9ce"},
-    {file = "mypy-0.960-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:85cf2b14d32b61db24ade8ac9ae7691bdfc572a403e3cb8537da936e74713275"},
-    {file = "mypy-0.960-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a85a20b43fa69efc0b955eba1db435e2ffecb1ca695fe359768e0503b91ea89f"},
-    {file = "mypy-0.960-cp39-cp39-win_amd64.whl", hash = "sha256:0ebfb3f414204b98c06791af37a3a96772203da60636e2897408517fcfeee7a8"},
-    {file = "mypy-0.960-py3-none-any.whl", hash = "sha256:bfd4f6536bd384c27c392a8b8f790fd0ed5c0cf2f63fc2fed7bce56751d53026"},
-    {file = "mypy-0.960.tar.gz", hash = "sha256:d4fccf04c1acf750babd74252e0f2db6bd2ac3aa8fe960797d9f3ef41cf2bfd4"},
+"mypy 0.961" = [
+    {file = "mypy-0.961-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:697540876638ce349b01b6786bc6094ccdaba88af446a9abb967293ce6eaa2b0"},
+    {file = "mypy-0.961-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b117650592e1782819829605a193360a08aa99f1fc23d1d71e1a75a142dc7e15"},
+    {file = "mypy-0.961-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bdd5ca340beffb8c44cb9dc26697628d1b88c6bddf5c2f6eb308c46f269bb6f3"},
+    {file = "mypy-0.961-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3e09f1f983a71d0672bbc97ae33ee3709d10c779beb613febc36805a6e28bb4e"},
+    {file = "mypy-0.961-cp310-cp310-win_amd64.whl", hash = "sha256:e999229b9f3198c0c880d5e269f9f8129c8862451ce53a011326cad38b9ccd24"},
+    {file = "mypy-0.961-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b24be97351084b11582fef18d79004b3e4db572219deee0212078f7cf6352723"},
+    {file = "mypy-0.961-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f4a21d01fc0ba4e31d82f0fff195682e29f9401a8bdb7173891070eb260aeb3b"},
+    {file = "mypy-0.961-cp36-cp36m-win_amd64.whl", hash = "sha256:439c726a3b3da7ca84a0199a8ab444cd8896d95012c4a6c4a0d808e3147abf5d"},
+    {file = "mypy-0.961-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5a0b53747f713f490affdceef835d8f0cb7285187a6a44c33821b6d1f46ed813"},
+    {file = "mypy-0.961-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0e9f70df36405c25cc530a86eeda1e0867863d9471fe76d1273c783df3d35c2e"},
+    {file = "mypy-0.961-cp37-cp37m-win_amd64.whl", hash = "sha256:b88f784e9e35dcaa075519096dc947a388319cb86811b6af621e3523980f1c8a"},
+    {file = "mypy-0.961-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d5aaf1edaa7692490f72bdb9fbd941fbf2e201713523bdb3f4038be0af8846c6"},
+    {file = "mypy-0.961-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6"},
+    {file = "mypy-0.961-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f4b794db44168a4fc886e3450201365c9526a522c46ba089b55e1f11c163750d"},
+    {file = "mypy-0.961-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:64759a273d590040a592e0f4186539858c948302c653c2eac840c7a3cd29e51b"},
+    {file = "mypy-0.961-cp38-cp38-win_amd64.whl", hash = "sha256:63e85a03770ebf403291ec50097954cc5caf2a9205c888ce3a61bd3f82e17569"},
+    {file = "mypy-0.961-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f1332964963d4832a94bebc10f13d3279be3ce8f6c64da563d6ee6e2eeda932"},
+    {file = "mypy-0.961-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:006be38474216b833eca29ff6b73e143386f352e10e9c2fbe76aa8549e5554f5"},
+    {file = "mypy-0.961-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9940e6916ed9371809b35b2154baf1f684acba935cd09928952310fbddaba648"},
+    {file = "mypy-0.961-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a5ea0875a049de1b63b972456542f04643daf320d27dc592d7c3d9cd5d9bf950"},
+    {file = "mypy-0.961-cp39-cp39-win_amd64.whl", hash = "sha256:1ece702f29270ec6af25db8cf6185c04c02311c6bb21a69f423d40e527b75c56"},
+    {file = "mypy-0.961-py3-none-any.whl", hash = "sha256:03c6cc893e7563e7b2949b969e63f02c000b32502a1b4d1314cabe391aa87d66"},
+    {file = "mypy-0.961.tar.gz", hash = "sha256:f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492"},
 ]
 "mypy-extensions 0.4.3" = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -105,6 +105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.47.0"
+requires_python = ">=3.7"
+summary = "A library for property-based testing"
+dependencies = [
+    "attrs>=19.2.0",
+    "sortedcontainers<3.0.0,>=2.1.0",
+]
+
+[[package]]
 name = "icontract"
 version = "2.6.1"
 summary = "Provide design-by-contract with informative violation messages."
@@ -331,6 +341,11 @@ requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 summary = "Python 2 and 3 compatibility utilities"
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+summary = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 requires_python = ">=3.7"
@@ -354,7 +369,7 @@ summary = "an efficient SMT solver library"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:538cff764f48185f366cb3eaf0e1364373777c65b39401db43961b10275d236b"
+content_hash = "sha256:2117a8444cb61689d13d5a04c98986812bc3fbc69b33461c073702d044acb3a8"
 
 [metadata.files]
 "asn1tools 0.163.0" = [
@@ -445,6 +460,10 @@ content_hash = "sha256:538cff764f48185f366cb3eaf0e1364373777c65b39401db43961b102
 "humanfriendly 10.0" = [
     {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
     {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
+]
+"hypothesis 6.47.0" = [
+    {file = "hypothesis-6.47.0-py3-none-any.whl", hash = "sha256:76a7d16f78b5691db34ef87fa677d020dd86189f6b748adf801088743b66c889"},
+    {file = "hypothesis-6.47.0.tar.gz", hash = "sha256:dd88c57f45032fc3d84596e426d8e3d67f88eda2d8a2d96a5697def036a7e0c7"},
 ]
 "icontract 2.6.1" = [
     {file = "icontract-2.6.1.tar.gz", hash = "sha256:dacfc55009993058cd17576faa291ab76b6f39d80ec9d1e524778cd79da11857"},
@@ -652,6 +671,10 @@ content_hash = "sha256:538cff764f48185f366cb3eaf0e1364373777c65b39401db43961b102
 "six 1.16.0" = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+"sortedcontainers 2.4.0" = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 "tomli 2.0.1" = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dev = [
     "pydbg>=0.3.0",
     "mypy>=0.942",
     "pytest-xdist[psutil]>=2.5.0",
-    "pytest-profiling>=1.7.0"]
+    "pytest-profiling>=1.7.0",
+    "hypothesis>=6.47.0",
+]
 
 [tool.pdm.scripts]
 main = "python -m asn2rflx"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dev = [
     "pydbg>=0.3.0",
     "mypy>=0.942",
     "pytest-xdist[psutil]>=2.5.0",
-    "pytest-profiling>=1.7.0",
-]
+    "pytest-profiling>=1.7.0"]
 
 [tool.pdm.scripts]
 main = "python -m asn2rflx"

--- a/src/asn2rflx/__main__.py
+++ b/src/asn2rflx/__main__.py
@@ -1,11 +1,12 @@
 import logging
 from pathlib import Path
 
+import asn1tools as asn1
 import coloredlogs
-from more_itertools import flatten
 from rflx.model.model import Model
 
-from .prelude import MODEL, OCTET_STRING, SequenceOfBerType
+from asn2rflx import prelude
+from asn2rflx.convert import AsnTypeConverter
 
 
 def greeting() -> str:
@@ -19,11 +20,13 @@ def main() -> None:
     outpath = Path("./build/rflx/specs/")
     logging.info(f"Writing specs to `{outpath.absolute()}`...")
     outpath.mkdir(parents=True, exist_ok=True)
-    sequence_of_types = [SequenceOfBerType("Test", OCTET_STRING.tlv_ty())]
+
     model = Model(
         types=[
-            *MODEL.types[:],
-            *flatten([ty.v_ty(), ty.lv_ty(), ty.tlv_ty()] for ty in sequence_of_types),
+            *prelude.MODEL.types,
+            *AsnTypeConverter()
+            .convert_spec(asn1.compile_files("assets/tagged.asn"))
+            .values(),
         ]
     )
     model.write_specification_files(outpath)

--- a/src/asn2rflx/convert.py
+++ b/src/asn2rflx/convert.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import singledispatchmethod
-from typing import cast
+from typing import Callable, cast
 
 import asn1tools as asn1
 from asn1tools.codecs import ber
@@ -18,52 +18,67 @@ class AsnTypeConverter:
 
     base_path: str = ""
 
+    def path(self, relpath: str) -> str:
+        return strid(list(filter(None, [self.base_path, relpath])))
+
     # In Python 3.10+ this should be done with the `match-case` construct...
     @singledispatchmethod
     def convert(self, _, relpath: str = "") -> prelude.BerType:
         raise NotImplementedError
 
+    def __convert_implicit(
+        self, base: prelude.BerType, val: ber.Type, relpath: str = ""
+    ) -> prelude.BerType:
+        if not val.tag_len:
+            return base
+        if val.tag_len > 1:
+            raise prelude.AsnTag.LONG_TAG_UNSUPPORTED_ERROR
+        tag = prelude.AsnTag.from_bytearray(val.tag)
+        if tag == base.tag:
+            return base
+        return base.implicitly_tagged(tag, self.path(relpath))
+
     # ASN.1 Types
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.Boolean, relpath: str = "") -> prelude.BerType:
-        return prelude.BOOLEAN
+    def _(self, val: ber.Boolean, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.BOOLEAN, val, relpath)
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.Null, relpath: str = "") -> prelude.BerType:
-        return prelude.NULL
+    def _(self, val: ber.Null, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.NULL, val, relpath)
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.Integer, relpath: str = "") -> prelude.BerType:
-        return prelude.INTEGER
+    def _(self, val: ber.Integer, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.INTEGER, val, relpath)
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.ObjectIdentifier, relpath: str = "") -> prelude.BerType:
-        return prelude.OBJECT_IDENTIFIER
+    def _(self, val: ber.ObjectIdentifier, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.OBJECT_IDENTIFIER, val, relpath)
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.BitString, relpath: str = "") -> prelude.BerType:
-        return prelude.BIT_STRING
+    def _(self, val: ber.BitString, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.BIT_STRING, val, relpath)
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.OctetString, relpath: str = "") -> prelude.BerType:
-        return prelude.OCTET_STRING
+    def _(self, val: ber.OctetString, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.OCTET_STRING, val, relpath)
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.PrintableString, relpath: str = "") -> prelude.BerType:
-        return prelude.PrintableString
+    def _(self, val: ber.PrintableString, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.PrintableString, val, relpath)
 
     @convert.register  # type: ignore [no-redef]
-    def _(self, _: ber.IA5String, relpath: str = "") -> prelude.BerType:
-        return prelude.IA5String
+    def _(self, val: ber.IA5String, relpath: str = "") -> prelude.BerType:
+        return self.__convert_implicit(prelude.IA5String, val, relpath)
 
     # ASN.1 type constructors
 
     @convert.register  # type: ignore [no-redef]
     def _(self, message: ber.Sequence, relpath: str = "") -> prelude.BerType:
         fields = cast(list[ber.Type], message.root_members)
-        return prelude.SequenceBerType(
-            strid(list(filter(None, [self.base_path, relpath]))),
+        res = prelude.SequenceBerType(
+            self.path(relpath),
             from_asn1_name(message.name),
             frozendict(
                 {
@@ -72,19 +87,21 @@ class AsnTypeConverter:
                 }
             ),
         )
+        return self.__convert_implicit(res, message, relpath)
 
     @convert.register  # type: ignore [no-redef]
     def _(self, sequence: ber.SequenceOf, relpath: str = "") -> prelude.BerType:
-        return prelude.SequenceOfBerType(
-            strid(list(filter(None, [self.base_path, relpath]))),
+        res = prelude.SequenceOfBerType(
+            self.path(relpath),
             self.convert(sequence.element_type, relpath).tlv_ty(),
         )
+        return self.__convert_implicit(res, sequence, relpath)
 
     @convert.register  # type: ignore [no-redef]
     def _(self, message: ber.Choice, relpath: str = "") -> prelude.BerType:
         fields = cast(list[ber.Type], message.members)
-        return prelude.ChoiceBerType(
-            strid(list(filter(None, [self.base_path, relpath]))),
+        res = prelude.ChoiceBerType(
+            self.path(relpath),
             from_asn1_name(message.name),
             frozendict(
                 {
@@ -93,6 +110,7 @@ class AsnTypeConverter:
                 }
             ),
         )
+        return self.__convert_implicit(res, message, relpath)
 
     def convert_spec(self, spec: asn1.compiler.Specification) -> dict[ID, model.Type]:
         """

--- a/src/asn2rflx/convert.py
+++ b/src/asn2rflx/convert.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import singledispatchmethod
-from typing import Callable, cast
+from typing import cast
 
 import asn1tools as asn1
 from asn1tools.codecs import ber

--- a/src/asn2rflx/prelude.py
+++ b/src/asn2rflx/prelude.py
@@ -150,7 +150,7 @@ class BerType(Protocol):
         """
         return ImplicitlyTaggedBerType(
             self,
-            AsnTag(num=tag.num, form=tag.form, class_=self.tag.class_),
+            AsnTag(num=tag.num, class_=tag.class_, form=self.tag.form),
             path or self.path,
         )
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -139,10 +139,13 @@ def test_tagged_decode(
 
     assert expected.get("Untagged_Value_name_Untagged_Value") == name1
 
-    got_payload = expected.get(f"Untagged_Value_payload_{choice}_Value")
+    payload_field = f"Untagged_Value_payload_{choice}_Value"
+    if variant.endswith("e"):  # Explicit tagging
+        payload_field += "_Inner_Untagged_Value"
     if is_one:
-        assert got_payload == encode_signed_integer(payload)
+        assert expected.get(payload_field) == encode_signed_integer(payload)
     else:
-        assert [i.bytestring[2:] for i in cast(list[MessageValue], got_payload)] == [
-            encode_signed_integer(i) for i in cast(list[int], payload)
-        ]
+        assert [
+            i.bytestring[2:]
+            for i in cast(list[MessageValue], expected.get(payload_field))
+        ] == [encode_signed_integer(i) for i in cast(list[int], payload)]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,4 +1,3 @@
-import random
 from typing import Union, cast
 
 import asn1tools as asn1
@@ -65,6 +64,7 @@ def test_foo_decode(
     ),
 )
 @hypot.example(range=0, name="", payload=0)
+@hypot.example(range=0, name="", payload=[])
 @hypot.settings(deadline=4 * 60000)
 @pytest.mark.xdist_group(name="rocket")
 def test_rocket_decode(
@@ -115,6 +115,11 @@ def test_rocket_decode(
         strats.lists(ASN_SHORT_INTS, max_size=4),
     ),
 )
+@hypot.example(name="", variant="ai", payload=[])
+@hypot.example(name="", variant="ae", payload=[])
+@hypot.example(name="", variant="ci", payload=[])
+@hypot.example(name="", variant="ce", payload=[])
+@hypot.settings(deadline=4 * 60000)
 @pytest.mark.xdist_group(name="tagged")
 def test_tagged_decode(
     name: str,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -28,7 +28,7 @@ ASN_SHORT_OCTET_STRINGS = strats.text(max_size=ASN_SHORT_LEN)
 # TODO: Support long lengths here.
 @hypot.given(id=ASN_SHORT_INTS, question=ASN_SHORT_IA5STRINGS)
 @hypot.example(id=0, question="")
-@hypot.settings(deadline=2 * 60000)
+@hypot.settings(deadline=None)
 @pytest.mark.xdist_group(name="foo")
 def test_foo_decode(
     id: int,
@@ -65,7 +65,7 @@ def test_foo_decode(
 )
 @hypot.example(range=0, name="", payload=0)
 @hypot.example(range=0, name="", payload=[])
-@hypot.settings(deadline=4 * 60000)
+@hypot.settings(deadline=None)
 @pytest.mark.xdist_group(name="rocket")
 def test_rocket_decode(
     range: int,
@@ -119,7 +119,7 @@ def test_rocket_decode(
 @hypot.example(name="", variant="ae", payload=[])
 @hypot.example(name="", variant="ci", payload=[])
 @hypot.example(name="", variant="ce", payload=[])
-@hypot.settings(deadline=4 * 60000)
+@hypot.settings(deadline=None)
 @pytest.mark.xdist_group(name="tagged")
 def test_tagged_decode(
     name: str,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,0 @@
-from asn2rflx.__main__ import greeting
-
-
-def test_greeting():
-    assert greeting() == "Hello from PDM!"

--- a/tests/test_prelude.py
+++ b/tests/test_prelude.py
@@ -1,0 +1,7 @@
+from asn2rflx import prelude
+
+
+def test_asn_tag_bytearray() -> None:
+    for byte in range(2**8):
+        arr = bytearray([byte])
+        assert prelude.AsnTag.from_bytearray(arr).as_bytearray == arr


### PR DESCRIPTION
Non-universal tagged types are declared in ASN.1 by adding a tag prefix to a regular type (eg. `[5] INTEGER`). This changes how the decorated tag is encoded in BER.

The syntax for tagging is the following:

- `[APPLICATION 5]` means changing the tag class to `APPLICATION = 0b01`, and tag number to `5`.
- `[5]` means changing the tag class to `CONTEXT = 0b10`, and tag number to `5`.
- `[PRIVATE 5]` means changing the tag class to `PRIVATE = 0b11`, and tag number to `5`.

The exact encoding depends on whether the tagging is `EXPLICIT` or `IMPLICIT`.

- When the tagging is `EXPLICIT` (default), the new tag is always `CONSTRUCTED = 0b1`, with the original encoding as its unique nested encoding.
- When the tagging is IMPLICIT, the encoding is the same as the base encoding except for the tag (the `FORM` (i.e. P/C) bit remains the same, other bits are replaced accordingly).

For example:
```smalltalk
             INTEGER = -27066   => 0x      02_02_9646
[5] IMPLICIT INTEGER = -27066   => 0x      85_02_9646
[5]          INTEGER = -27066   => 0xa5_04_02_02_9646
```
The tags above read:
- `02`: `UNIVERSAL_PRIMITIVE_INTEGER(2)`
- `85`: `CONTEXT_PRIMITIVE_5`
- `a5`: `CONTEXT_CONSTRUCTED_5`